### PR TITLE
Allow 4.2+ Ibexa Admin UI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": "^7.1 || ^8.0",
-    "ibexa/admin-ui": "~4.1.0",
+    "ibexa/admin-ui": "^4.1",
     "symfony/framework-bundle": "^5.0",
     "symfony/twig-bundle": "^5.0"
   },


### PR DESCRIPTION
`~4.1.0` means any `4.1.x` version. This effectively prevents the installation of currently supported 4.5/4.6.